### PR TITLE
Correções de padrão de desenvolvimento no Client.hpp

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -1,21 +1,21 @@
+#ifndef CLIENT_HPP
+#define CLIENT_HPP
+
 #include <string>
-
-using namespace std;
-
-#ifndef CLIENT_H
-#define CLIENT_H
 
 class Client {
     private:
-        string name;
-        int cpf;
+        std::string _name;
+        int _cpf;
 
     public:
-        Client(string name, int cpf): name(name), cpf(cpf) {};
-        void setName(string name);
-        string getName();
-        void setCpf(int cpf);
+        Client(std::string name, int cpf): _name(name), _cpf(cpf) {};
+
+        std::string getName();
         int getCpf();
+        
+        void setName(std::string name);
+        void setCpf(int cpf);
 };
 
 #endif


### PR DESCRIPTION
- Adição de _ antes do nome de variáveis privadas
- Utilização de camelCase
- Tirando a definição do uso do namespace std para todo o arquivo